### PR TITLE
Feature: Makefile with specific or additional parameters to run

### DIFF
--- a/roles/node_install/tasks/main.yml
+++ b/roles/node_install/tasks/main.yml
@@ -21,7 +21,7 @@
       args:
         chdir: '{{ user_dir }}/{{ folder }}'
       with_items:
-        - 'make install'
+        - 'make install {{ make_install_params }}'
       environment:
         PATH: '{{ path }}'
         GOPATH: '{{ user_dir }}/go'

--- a/vars/testnet/kyve.yml
+++ b/vars/testnet/kyve.yml
@@ -10,3 +10,4 @@ seeds: 'ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:11056'
 snapshot_url: 'https://snapshots.polkachu.com/snapshots/kyve/kyve_8283276.tar.lz4'
 custom_port_prefix: 120
 # minimum_gas_price: '0.025ucmdx'
+make_install_params: "ENV=mainnet"


### PR DESCRIPTION
certain chain repos seem to have specific or additional parameters to run the `make install` in our ansible playbooks so this should cover everything. 

Example Repo: https://github.com/KYVENetwork/chain/blob/main/Makefile

I have provided an example in the kyve testnet file

**_This is untested_**